### PR TITLE
Enable cache for the E2E tests

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -68,7 +68,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 'stable'
-          cache: false
 
       - name: Construct Database URLs
         run: |


### PR DESCRIPTION
Not sure why it was disabled in the first place.