### PR TITLE
Allow specifying request ID headers on the middleware

### DIFF
--- a/internal/uuid.go
+++ b/internal/uuid.go
@@ -1,0 +1,36 @@
+package internal
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+type UUID [16]byte
+
+func (u UUID) String() string {
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		u[0:4], u[4:6], u[6:8], u[8:10], u[10:16])
+}
+
+func NewUUIDV4() UUID {
+	var uuid UUID
+
+	// Fill the entire UUID with cryptographically secure random bytes.
+	if _, err := rand.Read(uuid[:]); err != nil {
+		panic(fmt.Sprintf("requestid: reading random bytes: %v", err))
+	}
+
+	// Set the version to 4.
+	// The 7th byte's most significant 4 bits are set to 0100.
+	// uuid[6] = (uuid[6] & 0x0F) | 0x40
+	// Clear the first 4 bits and then set the 4th bit.
+	uuid[6] = (uuid[6] & 0b00001111) | 0b01000000
+
+	// Set the variant to RFC 4122 (10xx).
+	// The 9th byte's most significant 2 bits are set to 10.
+	// uuid[8] = (uuid[8] & 0x3F) | 0x80
+	// Clear the first 2 bits and then set the 2nd bit.
+	uuid[8] = (uuid[8] & 0b00111111) | 0b10000000
+
+	return uuid
+}

--- a/requestid/context.go
+++ b/requestid/context.go
@@ -2,8 +2,6 @@ package requestid
 
 import (
 	"context"
-	"crypto/rand"
-	"fmt"
 )
 
 type requestIDCtxKey struct{}
@@ -13,42 +11,9 @@ func ContextWithRequestID(parent context.Context, requestID string) context.Cont
 	return context.WithValue(parent, requestIDCtxKey{}, requestID)
 }
 
-// ContextWithNewRequestID sets a new request ID on the context, returning the
-// ID.
-func ContextWithNewRequestID(parent context.Context) (_ context.Context, requestID string) {
-	rid := newRequestID()
-	return context.WithValue(parent, requestIDCtxKey{}, rid), rid
-}
-
 // FromContext returns the request ID from the context. If there is no
 // request ID in the context, ok will be false.
 func FromContext(ctx context.Context) (_ string, ok bool) {
 	v, ok := ctx.Value(requestIDCtxKey{}).(string)
 	return v, ok
-}
-
-// newRequestID generates a new uuidv4
-func newRequestID() string {
-	var uuid [16]byte
-
-	// Fill the entire UUID with cryptographically secure random bytes.
-	if _, err := rand.Read(uuid[:]); err != nil {
-		panic(fmt.Sprintf("requestid: reading random bytes: %v", err))
-	}
-
-	// Set the version to 4.
-	// The 7th byte's most significant 4 bits are set to 0100.
-	// uuid[6] = (uuid[6] & 0x0F) | 0x40
-	// Clear the first 4 bits and then set the 4th bit.
-	uuid[6] = (uuid[6] & 0b00001111) | 0b01000000
-
-	// Set the variant to RFC 4122 (10xx).
-	// The 9th byte's most significant 2 bits are set to 10.
-	// uuid[8] = (uuid[8] & 0x3F) | 0x80
-	// Clear the first 2 bits and then set the 2nd bit.
-	uuid[8] = (uuid[8] & 0b00111111) | 0b10000000
-
-	// Format the UUID into the standard 8-4-4-4-12 string representation.
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
-		uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:16])
 }

--- a/requestid/context_test.go
+++ b/requestid/context_test.go
@@ -3,6 +3,8 @@ package requestid
 import (
 	"context"
 	"testing"
+
+	"github.com/lstoll/web/internal"
 )
 
 func TestContext(t *testing.T) {
@@ -12,7 +14,8 @@ func TestContext(t *testing.T) {
 		t.Error("new context should not contain a request ID")
 	}
 
-	ctx, id := ContextWithNewRequestID(ctx)
+	id := internal.NewUUIDV4().String()
+	ctx = ContextWithRequestID(ctx, id)
 
 	gotID, ok := FromContext(ctx)
 	if !ok {
@@ -22,7 +25,7 @@ func TestContext(t *testing.T) {
 		t.Errorf("wanted request ID %s, got: %s", id, gotID)
 	}
 
-	newID := newRequestID()
+	newID := internal.NewUUIDV4().String()
 	ctx = ContextWithRequestID(ctx, newID)
 
 	gotID, ok = FromContext(ctx)

--- a/requestid/http_server.go
+++ b/requestid/http_server.go
@@ -2,24 +2,41 @@ package requestid
 
 import (
 	"net/http"
+
+	"github.com/lstoll/web/internal"
 )
 
-// Handler wraps a http.Handler, ensuring that a request ID exists on
-// the context downstream. If trustIncomingHeader is true, the request ID from
-// the incoming request header will be used if it exists.
-func Handler(trustIncomingHeader bool, next http.Handler) http.Handler {
+// Middleware is a middleware that ensures a request ID is present on the
+// context. If a request ID is found in one of the trusted headers, it will be
+// used. If not, a new request ID will be generated.
+type Middleware struct {
+	// TrustedHeaders is a list of headers that are trusted to contain the
+	// request ID. If a request ID is found in one of these headers, it will be
+	// used instead of generating a new one. It is processed in order, the first
+	// matching header is used.
+	TrustedHeaders []string
+}
+
+// Handler wraps a http.Handler, ensuring that a request ID exists on the
+// context downstream.
+func (m *Middleware) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var requestID string
-		if id, ok := FromContext(r.Context()); ok {
-			requestID = id
-		} else if trustIncomingHeader && r.Header.Get(RequestIDHeader) != "" {
-			requestID = r.Header.Get(RequestIDHeader)
-		} else {
-			requestID = newRequestID()
+		if _, ok := FromContext(r.Context()); ok {
+			// already in context, continue
+			next.ServeHTTP(w, r)
+			return
 		}
-
+		for _, hdr := range m.TrustedHeaders {
+			if id := r.Header.Get(hdr); id != "" {
+				requestID = id
+				break
+			}
+		}
+		if requestID == "" {
+			requestID = internal.NewUUIDV4().String()
+		}
 		r = r.WithContext(ContextWithRequestID(r.Context(), requestID))
-
 		next.ServeHTTP(w, r)
 	})
 }

--- a/server.go
+++ b/server.go
@@ -99,8 +99,7 @@ func NewServer(c *Config) (*Server, error) {
 	}
 
 	svr.BaseMiddleware.Append(MiddlewareRequestIDName, func(h http.Handler) http.Handler {
-		// TODO - make requestID be a normal middleware
-		return requestid.Handler(true, h)
+		return (&requestid.Middleware{}).Handler(h)
 	})
 	svr.BaseMiddleware.Append(MiddlewareRequestLogName, loghandler.Handler)
 	svr.BaseMiddleware.Append(MiddlewareErrorName, (&httperror.Handler{}).Handle)


### PR DESCRIPTION
Adopt the middleware pattern we've been using, allow it to set headers that are trusted to specify the remote headers that can set a request ID.

Fixes: #6 