### PR TITLE
Handlers for Proxy headers/TLS enforcement

### DIFF
--- a/proxyhdrs/forcetls.go
+++ b/proxyhdrs/forcetls.go
@@ -1,0 +1,43 @@
+package proxyhdrs
+
+import "net/http"
+
+type ForceTLS struct {
+	ForwardedProtoHeader string
+	HTTPMux              *http.ServeMux
+}
+
+func (h *ForceTLS) Handle(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var isHTTPS bool
+		if r.TLS != nil {
+			isHTTPS = true
+		} else if h.ForwardedProtoHeader != "" {
+			hdr := r.Header.Get(h.ForwardedProtoHeader)
+			if hdr == "https" {
+				isHTTPS = true
+			}
+		}
+		if isHTTPS {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// do a check if we have a plain-text handler, use it if so.
+		if h.HTTPMux != nil {
+			h, p := h.HTTPMux.Handler(r)
+			if p != "" {
+				h.ServeHTTP(w, r)
+				return
+			}
+		}
+
+		// otherwise, redirect to HTTPS
+		r.URL.Fragment = ""
+		redirectURL := "https://" + r.Host + r.URL.Path
+		if r.URL.RawQuery != "" {
+			redirectURL += "?" + r.URL.RawQuery
+		}
+		http.Redirect(w, r, redirectURL, http.StatusPermanentRedirect)
+	})
+}

--- a/proxyhdrs/forcetls_test.go
+++ b/proxyhdrs/forcetls_test.go
@@ -1,0 +1,164 @@
+package proxyhdrs
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestForceTLS_Handle(t *testing.T) {
+	tests := []struct {
+		name                 string
+		requestURL           string
+		tls                  bool
+		forwardedProtoHeader string
+		forwardedProtoValue  string
+		httpMux              *http.ServeMux
+		expectedStatusCode   int
+		expectedLocation     string
+		expectedResponseBody string
+	}{
+		{
+			name:                 "HTTPS request should pass through",
+			requestURL:           "https://example.com/test",
+			tls:                  true,
+			expectedStatusCode:   http.StatusOK,
+			expectedResponseBody: "success",
+		},
+		{
+			name:                 "HTTP request with forwarded proto https should pass through",
+			requestURL:           "http://example.com/test",
+			tls:                  false,
+			forwardedProtoHeader: "X-Forwarded-Proto",
+			forwardedProtoValue:  "https",
+			expectedStatusCode:   http.StatusOK,
+			expectedResponseBody: "success",
+		},
+		{
+			name:                 "HTTP request with custom forwarded proto header should pass through",
+			requestURL:           "http://example.com/test",
+			tls:                  false,
+			forwardedProtoHeader: "X-Custom-Forwarded-Proto",
+			forwardedProtoValue:  "https",
+			expectedStatusCode:   http.StatusOK,
+			expectedResponseBody: "success",
+		},
+		{
+			name:                 "HTTP request with forwarded proto http should redirect",
+			requestURL:           "http://example.com/test",
+			tls:                  false,
+			forwardedProtoHeader: "X-Forwarded-Proto",
+			forwardedProtoValue:  "http",
+			expectedStatusCode:   http.StatusPermanentRedirect,
+			expectedLocation:     "https://example.com/test",
+		},
+		{
+			name:                 "HTTP request with HTTP mux handler should use mux",
+			requestURL:           "http://example.com/plain",
+			tls:                  false,
+			httpMux:              createTestMux(),
+			expectedStatusCode:   http.StatusOK,
+			expectedResponseBody: "plain handler",
+		},
+		{
+			name:               "HTTP request without mux handler should redirect",
+			requestURL:         "http://example.com/test",
+			tls:                false,
+			expectedStatusCode: http.StatusPermanentRedirect,
+			expectedLocation:   "https://example.com/test",
+		},
+		{
+			name:                 "HTTP request with empty forwarded proto should redirect",
+			requestURL:           "http://example.com/test",
+			tls:                  false,
+			forwardedProtoHeader: "X-Forwarded-Proto",
+			forwardedProtoValue:  "",
+			expectedStatusCode:   http.StatusPermanentRedirect,
+			expectedLocation:     "https://example.com/test",
+		},
+		{
+			name:               "HTTP request with query parameters should redirect preserving params",
+			requestURL:         "http://example.com/test?param1=value1&param2=value2",
+			tls:                false,
+			expectedStatusCode: http.StatusPermanentRedirect,
+			expectedLocation:   "https://example.com/test?param1=value1&param2=value2",
+		},
+		{
+			name:               "HTTP request with custom port should redirect preserving port",
+			requestURL:         "http://example.com:8080/test",
+			tls:                false,
+			expectedStatusCode: http.StatusPermanentRedirect,
+			expectedLocation:   "https://example.com:8080/test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create the ForceTLS handler
+			forceTLS := &ForceTLS{
+				ForwardedProtoHeader: tt.forwardedProtoHeader,
+				HTTPMux:              tt.httpMux,
+			}
+
+			// Create a test handler that will be wrapped
+			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("success"))
+			})
+
+			// Wrap the test handler with ForceTLS
+			handler := forceTLS.Handle(testHandler)
+
+			// Create the request
+			req := httptest.NewRequest("GET", tt.requestURL, nil)
+
+			// Set up TLS if needed
+			if tt.tls {
+				req.TLS = &tls.ConnectionState{}
+			}
+
+			// Set forwarded proto header if provided
+			if tt.forwardedProtoHeader != "" {
+				req.Header.Set(tt.forwardedProtoHeader, tt.forwardedProtoValue)
+			}
+
+			// Create response recorder
+			w := httptest.NewRecorder()
+
+			// Serve the request
+			handler.ServeHTTP(w, req)
+
+			// Check status code
+			if w.Code != tt.expectedStatusCode {
+				t.Errorf("expected status code %d, got %d", tt.expectedStatusCode, w.Code)
+			}
+
+			// Check location header for redirects
+			if tt.expectedLocation != "" {
+				location := w.Header().Get("Location")
+				if location != tt.expectedLocation {
+					t.Errorf("expected location %s, got %s", tt.expectedLocation, location)
+				}
+			}
+
+			// Check response body for non-redirects
+			if tt.expectedResponseBody != "" {
+				body := w.Body.String()
+				if body != tt.expectedResponseBody {
+					t.Errorf("expected body %s, got %s", tt.expectedResponseBody, body)
+				}
+			}
+		})
+	}
+}
+
+// Helper function to create a test HTTP mux
+func createTestMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/plain", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("plain handler"))
+	})
+	return mux
+}

--- a/proxyhdrs/remoteip.go
+++ b/proxyhdrs/remoteip.go
@@ -1,0 +1,98 @@
+package proxyhdrs
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+)
+
+const (
+	ForwardedIPHeaderXFF         = "X-Forwarded-For"
+	ForwardedIPHeaderXRealIP     = "X-Real-IP"
+	ForwardedIPHeaderFlyClientIP = "Fly-Client-IP"
+)
+
+type contextKeyOriginalRequest struct{}
+
+// OriginalRequestFromContext returns the original request from the context,
+// before the header values were used.
+func OriginalRequestFromContext(ctx context.Context) (*http.Request, bool) {
+	originalRequest, ok := ctx.Value(contextKeyOriginalRequest{}).(*http.Request)
+	return originalRequest, ok
+}
+
+// ForwardedIPHeaderFormat specifies how the adress should be extracted from the
+// ForwardedIPHeader
+type ForwardedIPHeaderFormat uint32
+
+const (
+	// ForwardedIPHeaderFormatExact means the address is the exact address in the header
+	ForwardedIPHeaderFormatExact ForwardedIPHeaderFormat = iota
+	// ForwardedIPHeaderFormatFirst means the address is the first address in the header,
+	// comma separated.
+	ForwardedIPHeaderFormatFirst
+	// ForwardedIPHeaderFormatLast means the address is the last address in the
+	// header, comma separated.
+	ForwardedIPHeaderFormatLast
+)
+
+// RemoteIP is used as a middleware to handle re-writing request's IP addresses.
+// Used when the app is served behind a proxy that terminates requests and
+// re-writes what is sent to the backend.
+type RemoteIP struct {
+	// ForwardedIPHeader is the header that contains the original IP address.
+	// Required.
+	ForwardedIPHeader string
+	// ForwardedIPHeaderFormat specifies how the address should be extracted
+	// from the ForwardedIPHeader.
+	ForwardedIPHeaderFormat ForwardedIPHeaderFormat
+}
+
+// Handle wraps the handler, re-writing the request's IP address based on the
+// ForwardedIPHeader. The original request can be retrieved with
+// OriginalRequestFromContext
+func (h *RemoteIP) Handle(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), contextKeyOriginalRequest{}, r)
+		r = r.Clone(ctx)
+
+		if h.ForwardedIPHeader != "" {
+			hdr := r.Header.Get(h.ForwardedIPHeader)
+			if hdr != "" {
+				var ip net.IP
+
+				switch h.ForwardedIPHeaderFormat {
+				case ForwardedIPHeaderFormatExact:
+					ip = net.ParseIP(hdr)
+				case ForwardedIPHeaderFormatFirst:
+					// Split by comma and take the first non-empty, trimmed value
+					parts := strings.Split(hdr, ",")
+					for _, part := range parts {
+						trimmed := strings.TrimSpace(part)
+						if trimmed != "" {
+							ip = net.ParseIP(trimmed)
+							break
+						}
+					}
+				case ForwardedIPHeaderFormatLast:
+					// Split by comma and take the last non-empty, trimmed value
+					parts := strings.Split(hdr, ",")
+					for i := len(parts) - 1; i >= 0; i-- {
+						trimmed := strings.TrimSpace(parts[i])
+						if trimmed != "" {
+							ip = net.ParseIP(trimmed)
+							break
+						}
+					}
+				}
+
+				if ip != nil {
+					r.RemoteAddr = ip.String()
+				}
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/proxyhdrs/remoteip_test.go
+++ b/proxyhdrs/remoteip_test.go
@@ -1,0 +1,227 @@
+package proxyhdrs
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRemoteIP_Handle(t *testing.T) {
+	tests := []struct {
+		name                    string
+		forwardedIPHeader       string
+		forwardedIPHeaderFormat ForwardedIPHeaderFormat
+		requestIP               string
+		headerValue             string
+		expectedRemoteAddr      string
+		shouldModifyRemoteAddr  bool
+	}{
+		{
+			name:                    "X-Forwarded-For with exact format",
+			forwardedIPHeader:       ForwardedIPHeaderXFF,
+			forwardedIPHeaderFormat: ForwardedIPHeaderFormatExact,
+			requestIP:               "192.168.1.1:8080",
+			headerValue:             "203.0.113.1",
+			expectedRemoteAddr:      "203.0.113.1",
+			shouldModifyRemoteAddr:  true,
+		},
+		{
+			name:                    "X-Real-IP with exact format",
+			forwardedIPHeader:       ForwardedIPHeaderXRealIP,
+			forwardedIPHeaderFormat: ForwardedIPHeaderFormatExact,
+			requestIP:               "192.168.1.1:8080",
+			headerValue:             "203.0.113.2",
+			expectedRemoteAddr:      "203.0.113.2",
+			shouldModifyRemoteAddr:  true,
+		},
+		{
+			name:                    "Fly-Client-IP with exact format",
+			forwardedIPHeader:       ForwardedIPHeaderFlyClientIP,
+			forwardedIPHeaderFormat: ForwardedIPHeaderFormatExact,
+			requestIP:               "192.168.1.1:8080",
+			headerValue:             "203.0.113.3",
+			expectedRemoteAddr:      "203.0.113.3",
+			shouldModifyRemoteAddr:  true,
+		},
+		{
+			name:                    "X-Forwarded-For with first format",
+			forwardedIPHeader:       ForwardedIPHeaderXFF,
+			forwardedIPHeaderFormat: ForwardedIPHeaderFormatFirst,
+			requestIP:               "192.168.1.1:8080",
+			headerValue:             "203.0.113.1, 10.0.0.1, 172.16.0.1",
+			expectedRemoteAddr:      "203.0.113.1",
+			shouldModifyRemoteAddr:  true,
+		},
+		{
+			name:                    "X-Forwarded-For with last format",
+			forwardedIPHeader:       ForwardedIPHeaderXFF,
+			forwardedIPHeaderFormat: ForwardedIPHeaderFormatLast,
+			requestIP:               "192.168.1.1:8080",
+			headerValue:             "203.0.113.1, 10.0.0.1, 172.16.0.1",
+			expectedRemoteAddr:      "172.16.0.1",
+			shouldModifyRemoteAddr:  true,
+		},
+		{
+			name:                    "Empty header should not modify remote addr",
+			forwardedIPHeader:       ForwardedIPHeaderXFF,
+			forwardedIPHeaderFormat: ForwardedIPHeaderFormatExact,
+			requestIP:               "192.168.1.1:8080",
+			headerValue:             "",
+			expectedRemoteAddr:      "192.168.1.1:8080",
+			shouldModifyRemoteAddr:  false,
+		},
+		{
+			name:                    "Invalid IP should not modify remote addr",
+			forwardedIPHeader:       ForwardedIPHeaderXFF,
+			forwardedIPHeaderFormat: ForwardedIPHeaderFormatExact,
+			requestIP:               "192.168.1.1:8080",
+			headerValue:             "invalid-ip",
+			expectedRemoteAddr:      "192.168.1.1:8080",
+			shouldModifyRemoteAddr:  false,
+		},
+		{
+			name:                    "Empty forwarded header should not modify remote addr",
+			forwardedIPHeader:       "",
+			forwardedIPHeaderFormat: ForwardedIPHeaderFormatExact,
+			requestIP:               "192.168.1.1:8080",
+			headerValue:             "203.0.113.1",
+			expectedRemoteAddr:      "192.168.1.1:8080",
+			shouldModifyRemoteAddr:  false,
+		},
+		{
+			name:                    "IPv6 address with exact format",
+			forwardedIPHeader:       ForwardedIPHeaderXFF,
+			forwardedIPHeaderFormat: ForwardedIPHeaderFormatExact,
+			requestIP:               "[::1]:8080",
+			headerValue:             "2001:db8::1",
+			expectedRemoteAddr:      "2001:db8::1",
+			shouldModifyRemoteAddr:  true,
+		},
+		{
+			name:                    "Comma-separated values with spaces using first format",
+			forwardedIPHeader:       ForwardedIPHeaderXFF,
+			forwardedIPHeaderFormat: ForwardedIPHeaderFormatFirst,
+			requestIP:               "192.168.1.1:8080",
+			headerValue:             "  203.0.113.1  ,  10.0.0.1  ,  172.16.0.1  ",
+			expectedRemoteAddr:      "203.0.113.1",
+			shouldModifyRemoteAddr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create the RemoteIP handler
+			remoteIP := &RemoteIP{
+				ForwardedIPHeader:       tt.forwardedIPHeader,
+				ForwardedIPHeaderFormat: tt.forwardedIPHeaderFormat,
+			}
+
+			// Create a test handler that captures the request
+			var capturedRequest *http.Request
+			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedRequest = r
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("success"))
+			})
+
+			// Wrap the test handler with RemoteIP
+			handler := remoteIP.Handle(testHandler)
+
+			// Create the request
+			req := httptest.NewRequest("GET", "http://example.com/test", nil)
+			req.RemoteAddr = tt.requestIP
+
+			// Set the forwarded IP header if provided
+			if tt.forwardedIPHeader != "" && tt.headerValue != "" {
+				req.Header.Set(tt.forwardedIPHeader, tt.headerValue)
+			}
+
+			// Create response recorder
+			w := httptest.NewRecorder()
+
+			// Serve the request
+			handler.ServeHTTP(w, req)
+
+			// Check that the handler was called
+			if capturedRequest == nil {
+				t.Fatal("test handler was not called")
+			}
+
+			// Check remote addr
+			if capturedRequest.RemoteAddr != tt.expectedRemoteAddr {
+				t.Errorf("expected remote addr %s, got %s", tt.expectedRemoteAddr, capturedRequest.RemoteAddr)
+			}
+
+			// Check status code
+			if w.Code != http.StatusOK {
+				t.Errorf("expected status code %d, got %d", http.StatusOK, w.Code)
+			}
+
+			// Check response body
+			body := w.Body.String()
+			if body != "success" {
+				t.Errorf("expected body 'success', got '%s'", body)
+			}
+		})
+	}
+}
+
+func TestOriginalRequestFromContext(t *testing.T) {
+	// Create the RemoteIP handler
+	remoteIP := &RemoteIP{
+		ForwardedIPHeader:       ForwardedIPHeaderXFF,
+		ForwardedIPHeaderFormat: ForwardedIPHeaderFormatExact,
+	}
+
+	// Create a test handler that checks the context
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Get the original request from context
+		originalRequest, ok := OriginalRequestFromContext(r.Context())
+		if !ok {
+			t.Error("OriginalRequestFromContext returned false")
+			return
+		}
+
+		// Check that the original request has the original remote addr
+		if originalRequest.RemoteAddr != "192.168.1.1:8080" {
+			t.Errorf("expected original remote addr 192.168.1.1:8080, got %s", originalRequest.RemoteAddr)
+		}
+
+		// Check that the current request has the modified remote addr
+		if r.RemoteAddr != "203.0.113.1" {
+			t.Errorf("expected modified remote addr 203.0.113.1, got %s", r.RemoteAddr)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("success"))
+	})
+
+	// Wrap the test handler with RemoteIP
+	handler := remoteIP.Handle(testHandler)
+
+	// Create the request
+	req := httptest.NewRequest("GET", "http://example.com/test", nil)
+	req.RemoteAddr = "192.168.1.1:8080"
+	req.Header.Set(ForwardedIPHeaderXFF, "203.0.113.1")
+
+	// Create response recorder
+	w := httptest.NewRecorder()
+
+	// Serve the request
+	handler.ServeHTTP(w, req)
+
+	// Check status code
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status code %d, got %d", http.StatusOK, w.Code)
+	}
+}
+
+func TestOriginalRequestFromContext_NoContext(t *testing.T) {
+	// Test that OriginalRequestFromContext returns false when no context is set
+	ctx := context.Background()
+	_, ok := OriginalRequestFromContext(ctx)
+	if ok {
+		t.Error("OriginalRequestFromContext should return false when no context is set")
+	}
+}


### PR DESCRIPTION
It's pretty common to run apps behind some kind of proxy, which can change how we see the world. Remote IP and TLS checks are a good example, so add middleware to handle these.

The TLS one is a bit of a weird fit - it's partially proxy, but also I think that enforcing TLS is a good thing for us to do regardless. Will leave it here for now, worst case #8 picks it up.